### PR TITLE
Add "recipe" tag and config path in the .info file

### DIFF
--- a/content_browser_recipe.info
+++ b/content_browser_recipe.info
@@ -3,6 +3,8 @@ name = Content Browser Recipe
 description = A recipe to build a content browser view.
 package = Recipes
 backdrop = 1.x
+configure = admin/structure/views/view/content_browser
+tags[] = recipe
 
 dependencies[] = system (>=1.20.0)
 dependencies[] = views


### PR DESCRIPTION
@cellear this will add a "Configure" link that takes people to the view from the modules listing page + also a `recipe` tag (which might be useful in the future, when we allow filtering modules by tags).